### PR TITLE
Removed lonely `</div>`

### DIFF
--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -93,7 +93,6 @@ this template is the parent, while home/about are the children-->
   </div>
 
   </main>
-  </div>
 
 
 


### PR DESCRIPTION
This one was a quick fix. I couldn't seem to find the corresponding `<div>`.

Didn't seem to "hurt" anything at the moment, but was causing me some issues while I was tinkering.