### PR TITLE
Styling Breakout

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -60,4 +60,4 @@ def forums():
 @main.route('/profile')
 @login_required
 def profile():
-    return render_template('profile.html', name=current_user.name, email=current_user.email)
+    return render_template('profile/profile.html', name=current_user.name, email=current_user.email)

--- a/app/static/main.css
+++ b/app/static/main.css
@@ -102,12 +102,12 @@ h1{
     width: 33%;
     display: inline;
 
-    background: #ffffff;
+    /* background: #ffffff;
     padding: 10px 20px;
     border: 1px solid #dddddd;
     border-radius: 3px;
     margin-bottom: 20px;
-    margin-top: 30px;
+    margin-top: 30px; */
   }
 
   .profile-info {
@@ -117,4 +117,22 @@ h1{
     border-radius: 3px;
     margin-bottom: 20px;
     margin-right: 30px;
+  }
+
+  .profile-side-info {
+    background: #ffffff;
+    padding: 10px 20px;
+    border: 1px solid #dddddd;
+    border-radius: 3px;
+    margin-bottom: 20px;
+    margin-top: 30px;
+  }
+
+  .important-info-card {
+    background: #ffffff;
+    padding: 10px 20px;
+    border: 1px solid #dddddd;
+    border-radius: 3px;
+    margin-bottom: 20px;
+    margin-top: 30px;
   }

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -9,5 +9,7 @@
 {% endblock %}
 
 {% block rightblock %}
-    {% include "right_window/important_info.html" %}
+    <div class="important-info-card">
+        {% include "right_window/important_info.html" %}
+    </div>
 {% endblock %}

--- a/app/templates/profile/profile.html
+++ b/app/templates/profile/profile.html
@@ -1,10 +1,6 @@
-<!-- Logan Kiser: this is no longer called in the view, see profile/profile.html -->
+{% extends "profile/profile_main.html" %}
 
-{% extends "layout.html" %}
-
-{% block content %}
-
-<div class="profile-info">
+{% block profilecontent %}
 
   <form method="GET">
     <h2>Profile Information: Welcome, {{name}}!</h2>
@@ -27,12 +23,8 @@
       </div>
   </form>
 
-  {% block profilecontent %}{% endblock %}
-  
-</div>
-  
 {% endblock %}
 
-{% block rightblock %}
+{% block profileSideContent %}
   {% include "right_window/profile_info.html" %}
 {% endblock %}

--- a/app/templates/profile/profile_main.html
+++ b/app/templates/profile/profile_main.html
@@ -1,0 +1,15 @@
+{% extends "layout.html" %}
+
+{% block content %}
+
+  <div class="profile-info">
+    {% block profilecontent %}{% endblock %}
+  </div>
+
+{% endblock %}
+
+{% block rightblock %}
+  <div class="profile-side-info">
+    {% block profileSideContent %}{% endblock %}
+  </div>
+{% endblock %}


### PR DESCRIPTION
Once again, I will not be offended if we don't want to implement the sorts of changes I propose in this PR. My hope is that this approach proves fruitful once we've scaled a bit.

I'll leave some code snippet comments, but the meat of my proposal is to only allow "high level" templates/components to make broad styling decisions. E.g., `leftcontent` and `rightcontent` are (almost) the highest level container(s), so they would make decisions about layout / how things respond to smaller viewports / etc, but would not restrict "lower level" component trees to a specific font / padding / border / etc.

I'm a super newb, so I'm probably wrong about all of this. That said, in past projects, once things have scaled a bit, development has been severely hindered when all of our lower level components have been pigeon-holed into very specific styles.

Of course, if we **always** want a specific styling choice to persist on every single web page, we could bubble that up the template chain. Actually, when you have things setup right, it is pretty dang easy to make that change.

Note: I tossed Jasmine and Andy on this as reviewers because they have contributed to this branch. Feel free to add anyone that you feel should be privy to this discussion :)