### PR TITLE
Created layouts for middle article div and one half div.

### DIFF
--- a/app/templates/midArticleDiv.html
+++ b/app/templates/midArticleDiv.html
@@ -1,0 +1,7 @@
+{% extends "layout.html" %}
+
+{% block content %}
+    <div class = "mainDiv">
+        <div class="midArticleDiv"> {% block midArticleContent %}{% endblock %} </div>
+    </div>
+{% endblock %}


### PR DESCRIPTION
I accidentally pushed these changes inside Andy's 41-main-div-css-layouts, sorry about that!

midArticleDiv is a centered div inside of a main div. Borders are not included in the code.
<img width="1158" alt="Screen Shot 2022-07-12 at 9 55 04 AM" src="https://user-images.githubusercontent.com/104233607/178549649-f5416838-b91d-4182-9198-349cfee93e48.png">

oneHalfDiv is two divs that evenly take up one half of their container div.
<img width="1158" alt="Screen Shot 2022-07-12 at 10 00 06 AM" src="https://user-images.githubusercontent.com/104233607/178550329-cb67c630-c705-42bc-aa6c-c11f2f530feb.png">

