### PR TITLE
426 company restoration

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,3 @@
-import os
 from flask import Flask, request, send_from_directory
 from flask_login import LoginManager, current_user
 from flask_principal import (AnonymousIdentity, Principal, Permission, RoleNeed, UserNeed,
@@ -35,7 +34,6 @@ class DummyHome():
 
 def create_app():
     app = Flask(__name__, static_folder='static')
-    app.debug = os.environ.get('FLASK_DEBUG', 'False') == 'True'
     
     # SQLAlchemy Config
     app.config['SECRET_KEY'] = id()

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,3 +1,4 @@
+import os
 from flask import Flask, request, send_from_directory
 from flask_login import LoginManager, current_user
 from flask_principal import (AnonymousIdentity, Principal, Permission, RoleNeed, UserNeed,
@@ -34,7 +35,8 @@ class DummyHome():
 
 def create_app():
     app = Flask(__name__, static_folder='static')
-
+    app.debug = os.environ.get('FLASK_DEBUG', 'False') == 'True'
+    
     # SQLAlchemy Config
     app.config['SECRET_KEY'] = id()
     app.config.update(config)

--- a/app/routes/companies.py
+++ b/app/routes/companies.py
@@ -9,6 +9,25 @@ company_info = Blueprint('company_info', __name__, url_prefix="/company")
 admin_permission = Permission(RoleNeed('admin'))
 
 
+# Filtered for current_user
+#@company_info.route("/")
+#@login_required
+#def display_companies_home():
+    #if request.method == "POST":
+        #page = int(request.form.get('page_number', 1))
+    #else:
+        #page = 1
+
+    #companies = paginate_join(Company, CompanyMembers, CompanyMembers.company_id == Company.id, page=page, 
+                              #pages=10, filters={'user_id': current_user.id})
+
+    #print(companies)
+    #print(companies.items)
+
+    #return render_template('company_info/company_info_main.html',
+                           #companies=companies, is_admin=admin_permission.can(), primary_title='Companies')
+
+#TO-DO: check to see if handles next page (passed 10 queries)
 @company_info.route("/")
 @login_required
 def display_companies_home():
@@ -17,11 +36,15 @@ def display_companies_home():
     else:
         page = 1
 
-    companies = paginate_join(Company, CompanyMembers, CompanyMembers.company_id == Company.id, page=page, 
-                              pages=10, filters={'user_id': current_user.id})
+    # Using direct pagination on Company model,
+    companies = Company.query.paginate(page=page, per_page=10, error_out=False)
+
+    print(companies)
+    print(companies.items)
 
     return render_template('company_info/company_info_main.html',
                            companies=companies, is_admin=admin_permission.can(), primary_title='Companies')
+
 
 
 @company_info.route('/<company_id>', methods=['POST','GET'])

--- a/app/routes/companies.py
+++ b/app/routes/companies.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, redirect, render_template, request, url_for, flash
+from flask import Blueprint, redirect, render_template, request, url_for
 from flask_login import current_user, login_required
 from flask_principal import Permission, RoleNeed
 from app.db import db, paginate, paginate_join
@@ -7,31 +7,6 @@ from app.util.security.limit import limiter
 
 company_info = Blueprint('company_info', __name__, url_prefix="/company")
 admin_permission = Permission(RoleNeed('admin'))
-
-
-# Filtered for current user & using paginate_join
-#@company_info.route("/")
-#@login_required
-#def display_companies_home():
-    #if request.method == "POST":
-        #page = int(request.form.get('page_number', 1))
-    #else:
-        #page = 1
-
-    #companies = paginate_join(Company, CompanyMembers, CompanyMembers.company_id == Company.id, page=page, 
-                              #pages=10, filters={'user_id': current_user.id})
-
-    #print(companies)
-    #print(companies.items)
-
-    #return render_template('company_info/company_info_main.html',
-                           #companies=companies, is_admin=admin_permission.can(), primary_title='Companies')
-
-
-# COMMENTS: 
-# 1. Check to see if handles next page (passed 10 queries)
-# 2. Re-do to use paginate_join from db util instead of flask built-in paginate? 
-# 3. admin_permissions.can() within function, inconsistency with admin decorator 
         
 
 @company_info.route("/", methods=['GET', 'POST'])
@@ -52,15 +27,12 @@ def display_companies_home():
             return redirect(url_for('company_info.display_company_info', company_id=member_company.company_id))
         return render_template('company_info/no_company.html')
 
-    # Check if the user is an admin early on to keep logic straightforward
     is_admin = admin_permission.can()
 
     if is_admin:
         return handle_admin_view()
     else:
         return handle_user_view()
-
-
 
 
 @company_info.route('/<company_id>', methods=['POST','GET'])
@@ -150,10 +122,6 @@ def edit_company_info_post(company_id):
     return render_template('company_info/company_edit.html', company=company, primary_title='Edit Company')
 
 
-# TO-DO: 
-# Current functionality displays per page the amount of checked members from members/edit route
-# i.e., 3 out of 10 total members present in company for page 1, thus displaying only 3 members
-# i.e., 6 out of 10 total members present in company for page 2, thus displaying only 6 members
 @company_info.route('/<company_id>/members', methods=['GET', 'POST'])
 @login_required
 def display_company_members(company_id):

--- a/app/templates/company_info/company_info.html
+++ b/app/templates/company_info/company_info.html
@@ -2,10 +2,8 @@
 {% import "macros/paginate.html" as pagination %}
 
 {% block pageDropDowns %}
-  {% if is_admin %}
     <a href="/company/{{company.id}}/edit">Edit Company</a>
     <a href="/company/{{company.id}}/members">View Members</a>
-  {% endif %}
 {% endblock %}
 
 {% block pageContent %}

--- a/app/templates/company_info/company_info.html
+++ b/app/templates/company_info/company_info.html
@@ -4,6 +4,7 @@
 {% block pageDropDowns %}
   {% if is_admin %}
     <a href="/company/{{company.id}}/edit">Edit Company</a>
+    <a href="/company/{{company.id}}/members">View Members</a>
   {% endif %}
 {% endblock %}
 

--- a/app/templates/company_info/company_info_create.html
+++ b/app/templates/company_info/company_info_create.html
@@ -1,7 +1,7 @@
 {% extends "layout/fullPageScroll.html" %}
 
 {% block pageContent %}
-        <form class="form" method="POST" action="/companies/create">
+        <form class="form" method="POST" action="/company/create">
             <div class="form-section">
                 <label>Company Name*</label>
                 <input class="form-input" type="text" name="name" placeholder="Company Name" required>

--- a/app/templates/company_info/company_info_main.html
+++ b/app/templates/company_info/company_info_main.html
@@ -8,10 +8,9 @@
 {% block pageContent %}
   <p>Please click on a link below to view a specific company's information.</p>
   <ul class="company-list">
-    {% for company in companies %}
+    {% for company in companies.items %}
       <li><a href="/company/{{ company.id }}">{{ company.name|e }}</a></li>
     {% endfor %}
   </ul>
   {{ pagination.render_pagination(companies, "") }}
 {% endblock %}
-

--- a/app/templates/company_info/display_members.html
+++ b/app/templates/company_info/display_members.html
@@ -3,9 +3,7 @@
 
 
 {% block pageDropDowns %}
-  {% if is_admin %}
     <a href="/company/{{company.id}}/members/edit">Edit Members</a>
-  {% endif %}
 {% endblock %}
 
 {% block pageContent %}

--- a/app/templates/company_info/display_members.html
+++ b/app/templates/company_info/display_members.html
@@ -1,0 +1,25 @@
+{% extends "layout/fullPageScroll.html" %}
+{% import "macros/paginate.html" as pagination %}
+
+
+{% block pageDropDowns %}
+  {% if is_admin %}
+    <a href="/company/{{company.id}}/members/edit">Edit Members</a>
+  {% endif %}
+{% endblock %}
+
+{% block pageContent %}
+<div class="content-section">
+  <h1 class="profile-title">Members of {{ company.name }}</h1>
+  <div class="member-list">
+    <ul>
+      {% for user in users %}
+        {% if user.id in members_ids_list %}
+          <li>{{ user.name }} - {{ user.email }}</li> <!-- Adjust according to your User model attributes -->
+        {% endif %}
+      {% endfor %}
+    </ul>
+    {{ pagination.render_pagination(users, "/company/" + company.id + "/members") }}
+  </div>
+</div>
+{% endblock %}

--- a/app/templates/company_info/no_company.html
+++ b/app/templates/company_info/no_company.html
@@ -1,0 +1,10 @@
+{% extends "layout/fullPageScroll.html" %}
+{% import "macros/paginate.html" as pagination %}
+
+{% block pageDropDowns %}
+  {% include "right_window/profile_info.html" %}
+{% endblock %}
+
+{% block pageContent %}
+  <p>You are not a member of any company.</p>
+{% endblock %}

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -36,7 +36,7 @@
               <div class="dropdown">
                 <div class="dropdown-btn">Tools</div>
                 <div class="dropdown-content">
-                  <a href="/company/editor">Company</a>
+                  <a href="/company">Company</a>
                   <a href="/orders/editor">Orders</a>
                   <a href="/customers/editor">Customers</a>
                   <a href="/blog/create">New Blog</a>

--- a/app/templates/right_window/profile_info.html
+++ b/app/templates/right_window/profile_info.html
@@ -1,5 +1,6 @@
 <a href="/profile" >Personal Info</a>
 <a href="/company" >Company Info</a>
+<a href="/company/create" >Create Company</a>
 <a href="/orders" >Order Info</a>
 <a href="/calendar" >Calendar</a>
 


### PR DESCRIPTION
### Updates:

**1. LInks/View/Routes for Companies:**
   - Full functionality achieved for both user and admin.
   
**2. Added 'View Members' template(s):**
   - Added functionality to view company members and provided a template for users who are not members of any company.

**3. Logic Concerns (companies.py):**

`display_companies_home():
`
- _Next Page Functionality:_ Ensure the function correctly handles pagination beyond the first 10 queries.
- _Utilize paginate_join:_ Removed usage of using paginate_join from the DB utility, for instead, Flask's built-in paginate.
- _Permissions Check:_ Address any inconsistencies with the use of admin_permission.can() _within_ the function, instead of admin decorator.

`display_company_members():
`
- _Pagination Logic:_ A need to adjust to correctly display a consistent number of users per page (ideally 10)?